### PR TITLE
[Design] #26 - 이용 내역 View 구현

### DIFF
--- a/NoHelmetNoRide/Mypage/UsageHistoryCell.swift
+++ b/NoHelmetNoRide/Mypage/UsageHistoryCell.swift
@@ -43,9 +43,9 @@ class UsageHistoryCell: UITableViewCell {
         
         logoImageView.image = .icon
         logoImageView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(16)
             $0.leading.equalToSuperview().offset(19)
             $0.width.height.equalTo(18)
+            $0.centerY.equalTo(kickboardIdLabel.snp.centerY)
         }
         
         kickboardIdLabel.text = "킥보드 ID:"

--- a/NoHelmetNoRide/Mypage/UsageHistoryCell.swift
+++ b/NoHelmetNoRide/Mypage/UsageHistoryCell.swift
@@ -1,0 +1,83 @@
+//
+//  UsageHistoryCell.swift
+//  NoHelmetNoRide
+//
+//  Created by 전원식 on 4/28/25.
+//
+
+import UIKit
+import SnapKit
+
+class UsageHistoryCell: UITableViewCell {
+    // MARK: - Property
+    let logoImageView = UIImageView()
+    let kickboardIdLabel = UILabel()
+    let dateLabel = UILabel()
+    let drivingInfoLabel = UILabel()
+    let priceLabel = UILabel()
+
+    // MARK: - Life Cycle
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupCell()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        contentView.layer.cornerRadius = 20
+        contentView.layer.borderWidth = 1
+        contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 0, left: 4, bottom: 24, right: 4))
+    }
+
+    // MARK: - Method
+    private func setupCell() {
+        contentView.addSubview(logoImageView)
+        contentView.addSubview(kickboardIdLabel)
+        contentView.addSubview(dateLabel)
+        contentView.addSubview(drivingInfoLabel)
+        contentView.addSubview(priceLabel)
+        
+        logoImageView.image = .icon
+        logoImageView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(16)
+            $0.leading.equalToSuperview().offset(19)
+            $0.width.height.equalTo(18)
+        }
+        
+        kickboardIdLabel.text = "킥보드 ID:"
+        kickboardIdLabel.font = .systemFont(ofSize: 14, weight: .semibold)
+        kickboardIdLabel.textColor = .font
+        kickboardIdLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(14)
+            $0.leading.equalTo(logoImageView.snp.trailing).offset(8)
+        }
+        
+        dateLabel.text = "날짜: 25.04.27"
+        dateLabel.font = .systemFont(ofSize: 12)
+        dateLabel.textColor = .font
+        dateLabel.snp.makeConstraints {
+            $0.top.equalTo(kickboardIdLabel.snp.bottom).offset(8)
+            $0.leading.equalTo(kickboardIdLabel)
+        }
+        
+        drivingInfoLabel.text = "운행: 00분, 00KM"
+        drivingInfoLabel.font = .systemFont(ofSize: 12)
+        drivingInfoLabel.textColor = .font
+        drivingInfoLabel.snp.makeConstraints {
+            $0.top.equalTo(dateLabel.snp.bottom).offset(4)
+            $0.leading.equalTo(kickboardIdLabel)
+        }
+        
+        priceLabel.text = "요금: 00000원"
+        priceLabel.font = .systemFont(ofSize: 12)
+        priceLabel.textColor = .font
+        priceLabel.snp.makeConstraints {
+            $0.top.equalTo(drivingInfoLabel.snp.bottom).offset(4)
+            $0.leading.equalTo(kickboardIdLabel)
+        }
+    }
+}

--- a/NoHelmetNoRide/Mypage/UsageHistoryView.swift
+++ b/NoHelmetNoRide/Mypage/UsageHistoryView.swift
@@ -1,0 +1,34 @@
+//
+//  UsageHistoryView.swift
+//  NoHelmetNoRide
+//
+//  Created by 전원식 on 4/28/25.
+//
+
+import UIKit
+import SnapKit
+
+class UsageHistoryView: UIView {
+    let tableView = UITableView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupView() {
+        backgroundColor = .white
+        tableView.backgroundColor = .white
+        addSubview(tableView)
+        
+        tableView.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide).offset(46)
+            $0.leading.trailing.equalToSuperview().inset(12)
+            $0.bottom.equalTo(safeAreaLayoutGuide)
+        }
+    }
+}

--- a/NoHelmetNoRide/Mypage/UsageHistoryViewController.swift
+++ b/NoHelmetNoRide/Mypage/UsageHistoryViewController.swift
@@ -1,0 +1,56 @@
+//
+//  UsageHistoryViewController.swift
+//  NoHelmetNoRide
+//
+//  Created by 전원식 on 4/28/25.
+//
+
+import UIKit
+
+class UsageHistoryViewController: UIViewController {
+    private let usageHistoryView = UsageHistoryView()
+    
+    override func loadView() {
+        self.view = usageHistoryView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupNavigation()
+        setupTableView()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.isNavigationBarHidden = false
+    }
+    
+    private func setupNavigation() {
+        self.navigationItem.title = "이용 내역"
+    }
+    
+    private func setupTableView() {
+        usageHistoryView.tableView.delegate = self
+        usageHistoryView.tableView.dataSource = self
+        usageHistoryView.tableView.register(UsageHistoryCell.self, forCellReuseIdentifier: "UsageHistoryCell")
+    }
+}
+
+extension UsageHistoryViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 134
+    }
+}
+
+extension UsageHistoryViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 5
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "UsageHistoryCell", for: indexPath) as? UsageHistoryCell else {
+            return UITableViewCell()
+        }
+        return cell
+    }
+}


### PR DESCRIPTION
close #26

## *⛳️ Work Description*
- 이용 내역 View 구현
 
## *📸 Screenshot*
<img width="497" alt="스크린샷 2025-04-29 04 17 22" src="https://github.com/user-attachments/assets/47851262-b742-41e8-8fcd-a6aef6d51e2d" />



## *📢 To Reviewers*
- [x] 이용 내역 View 구현

## *✅ Checklist*
- [x] 컨벤션 준수 확인.